### PR TITLE
successfully retrieve full file list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "retryable", "~> 3.0"

--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -34,6 +34,9 @@ option_parser = OptionParser.new do |opts|
     options[:exact_url] = t
   end
 
+  opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
+    options[:only_filter] = t
+
   opts.on("-w", "--wait SECONDS", Integer, "Wait the specified number of seconds between requests") do |t|
     options[:wait_seconds] = t
   end

--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -46,6 +46,10 @@ option_parser = OptionParser.new do |opts|
     options[:wait_randomize] = true
   end
 
+  opts.on("--tries NUMBER", Integer, "Number of times to retry for non-fatal connection errors (Default is 20)") do |t|
+    options[:tries] = t
+  end
+
   opts.on("-x", "--exclude EXCLUDE_FILTER", String, "Skip downloading of urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
     options[:exclude_filter] = t
   end

--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -34,8 +34,12 @@ option_parser = OptionParser.new do |opts|
     options[:exact_url] = t
   end
 
-  opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
-    options[:only_filter] = t
+  opts.on("-w", "--wait SECONDS", Integer, "Wait the specified number of seconds between requests") do |t|
+    options[:wait_seconds] = t
+  end
+
+  opts.on("--random-wait", "When used with --wait, randomize number of seconds waited between requests by a factor of 0.5 to 2") do |t|
+    options[:wait_randomize] = true
   end
 
   opts.on("-x", "--exclude EXCLUDE_FILTER", String, "Skip downloading of urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|

--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -36,6 +36,7 @@ option_parser = OptionParser.new do |opts|
 
   opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
     options[:only_filter] = t
+  end
 
   opts.on("-w", "--wait SECONDS", Integer, "Wait the specified number of seconds between requests") do |t|
     options[:wait_seconds] = t

--- a/lib/wayback_machine_downloader.rb
+++ b/lib/wayback_machine_downloader.rb
@@ -268,7 +268,8 @@ class WaybackMachineDownloader
         structure_dir_path dir_path
         open(file_path, "wb") do |file|
           begin
-            open("http://web.archive.org/web/#{file_timestamp}id_/#{file_url}", "Accept-Encoding" => "plain") do |uri|
+            file_url_escaped = CGI.escape file_url
+            URI.open("http://web.archive.org/web/#{file_timestamp}id_/#{file_url_escaped}", "Accept-Encoding" => "plain") do |uri|
               file.write(uri.read)
             end
           rescue OpenURI::HTTPError => e

--- a/lib/wayback_machine_downloader/archive_api.rb
+++ b/lib/wayback_machine_downloader/archive_api.rb
@@ -5,7 +5,9 @@ module ArchiveAPI
     request_url += CGI.escape url
     request_url += parameters_for_api page_index
 
-    URI.open(request_url).read
+    Retryable.retryable(tries: @tries, on: Net::ReadTimeout, sleep_method: self.method(:wait)) do
+      URI.open(request_url).read
+    end
   end
 
   def parameters_for_api page_index

--- a/lib/wayback_machine_downloader/archive_api.rb
+++ b/lib/wayback_machine_downloader/archive_api.rb
@@ -2,10 +2,10 @@ module ArchiveAPI
 
   def get_raw_list_from_api url, page_index
     request_url = "http://web.archive.org/cdx/search/xd?url="
-    request_url += url
+    request_url += CGI.escape url
     request_url += parameters_for_api page_index
 
-    open(request_url).read
+    URI.open(request_url).read
   end
 
   def parameters_for_api page_index


### PR DESCRIPTION
For me command was failing with
```
Getting snapshot pages../home/avalon/.asdf/installs/ruby/3.1.3/lib/ruby/3.1.0/open-uri.rb:364:in `open_http': 400 BAD REQUEST (OpenURI::HTTPError)
```

Turns out that wayback returns 400 nowadays.

This patch sits on top of the great patches of @morgant because they are also needed. Basically this is a superset of #4, #5 and #6